### PR TITLE
Feat: added mecruit as a job board under Job Board Category

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Job board with a listing of jobs available mainly in Africa.
 
 Job board for Android Developers.
 
+### [Mecruit Job Board](https://www.mecruit.com/)
+
+Jobs Across the Globe at Top Tier Companies with extensive filter options(eg: remote, visa sponsored, salary mentioned etc)
+
 #### Honorable mentions
 
  - [Who Is Hiring?](https://whoishiring.io/) like HN Hiring aims to cover the job posts on HN. It seems to be updated less often, but the UI/UX looks great.


### PR DESCRIPTION
Hi,

I have added my Job Board in your repo under the #Job Boards category.

The job boards is - https://www.mecruit.com/

We claim to offer extensive filter options to job applicants(eg: remote, visa sponsored, salary mentioned etc)
which helps job applicants to find job openings fast with only the filters that matter to them.

We also have a newsletter for the preferred filters of the job applicants.

Please help us by sharing this job board in your repository.

Best Regards