### PR TITLE
Update README.md - Add Top Jobs Today to Job Boards section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Unique freelance jobs from only IT industry.
 
 Tons of startups with 1 click applications.
 
+### [Top Jobs Today](https://topjobstoday.com/)
+
+Daily updated listings of fresh FAANG & big tech jobs scraped directly from company career pages.
+
 ### [Remotely Awesome Jobs](https://www.remotelyawesomejobs.com/)
 
 Remotely awesome focuses on remote jobs! It crawls lots of job boards, and employers can also create postings directly.


### PR DESCRIPTION
This PR adds https://topjobstoday.com to the Job Boards section.
Top Jobs Today is a curated site that lists fresh FAANG & big tech jobs, scraped daily from company career pages helping job seekers find high-paying tech roles before they appear on major job boards.

Thanks for maintaining this great list!