### PR TITLE
Add FoundRole to Job Boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ More than 9000 employment agencies listed in the US and their jobs offers
 ### [warpjobs](https://warpjobs.com)
 
 A niche board for GPU/CUDA, ML-systems, inference and performance-engineering roles, aggregated daily from AI-lab and infra companies' public ATS feeds (Greenhouse/Lever/Ashby). Open-source scraper, RSS and JSON feeds, no login.
+### [FoundRole](https://www.foundrole.com/)
+
+Free job search platform with AI search, a Kanban application tracker, and career tools in one place.
 
 #### Honorable mentions
 


### PR DESCRIPTION
## What is FoundRole?

FoundRole is a free job search platform that brings AI search, a Kanban application tracker, and career tools into one place. Job seekers can search live listings through an AI interface, drag applications across a built-in Kanban board, and connect AI assistants like Claude or ChatGPT directly to job data via an open-source MCP server — all without a paid subscription.

**What makes it different:**

- **AI-native search** — query jobs through an AI interface rather than filter dropdowns
- **Built-in Kanban tracker** — replaces the spreadsheets and tabs most job seekers cobble together
- **MCP integration** — open-source server lets Claude, ChatGPT, and other MCP-compatible assistants search and track jobs from chat
- **Free core** — search, tracker, and career tools are free with no credit-card wall

**Why the Job Boards section:** FoundRole is a general-purpose job search platform serving the same broad audience this list targets — job seekers looking for alternatives to the major boards.